### PR TITLE
Update Bootstrap/Jquery and add CDN support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ In this case a sqlite database is used by default. You need to create the direct
 
     mkdir data
 
+**Peer5 Support**
+
+Peer5 is a free CDN that allows website owners to reduce bandwidth by using P2P technology.
+
+    To enable Peer5, please input your ID in website/templates/layout.jade
+
 **Start your application server:**
 
     cm-update-server$ export NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "cm-update-server",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"author": "Martin Blumenstingl <martin.blumenstingl [AT] googlemail.com>",
 	"description": "Server component which is compatible with CyanogenMod's CMUpdater application.",
 	"main": "cm-update-server.js",
@@ -13,19 +13,19 @@
 
 	"dependencies": {
 		"troll-opt" : ">= 0.7.x",
-		"config": ">= 0.4.x",
-		"restify": ">= 3.0.x",
-		"sequelize-cli": "^1.7.0",
-		"sequelize": ">= 2.0.5"
+		"config": ">= 1.16.x",
+		"restify": ">= 4.0.x",
+		"sequelize-cli": "^2.0.0",
+		"sequelize": ">= 3.12.1"
 	},
 
 	"optionalDependencies": {
-		"sqlite3": ">= 3.0.5",
-		"mysql": ">= 2.x",
-		"mariasql": ">= 0.1.x",
-		"wintersmith": ">= 2.1.x",
-		"fs-extra": ">= 0.10.0",
-		"filesize": ">= 2.0.0",
-		"async": ">= 0.9.0"
+		"sqlite3": ">= 3.1.x",
+		"mysql": ">= 2.9.x",
+		"mariasql": ">= 0.2.x",
+		"wintersmith": ">= 2.2.x",
+		"fs-extra": ">= 0.24.0",
+		"filesize": ">= 3.1.3",
+		"async": ">= 1.4.2"
 	}
 }

--- a/website/templates/layout.jade
+++ b/website/templates/layout.jade
@@ -8,13 +8,15 @@ html(lang='en')
       meta(charset='utf-8')
       meta(http-equiv='X-UA-Compatible', content='IE=edge,chrome=1')
       meta(name='viewport', content='width=device-width')
+      meta(name='theme-color', content='#005bff')
       title
         block title
           = locals.name
 
-    - var bootstrapVersion = '3.2.0'
-    - var jqueryVersion = '1.11.1'
-    - var datatablesVersion = '1.10.1'
+    - var bootstrapVersion = '3.3.5'
+    - var jqueryVersion = '1.11.3'
+    - var datatablesVersion = '1.10.9'
+    - var peer5Key = 'XXXXXXXXXX'
 
     link(rel='stylesheet', href='//maxcdn.bootstrapcdn.com/bootstrap/#{bootstrapVersion}/css/bootstrap.min.css')
     link(rel='stylesheet', href='//cdn.datatables.net/#{datatablesVersion}/css/jquery.dataTables.css')
@@ -23,6 +25,7 @@ html(lang='en')
     script(type='text/javascript', src='//code.jquery.com/jquery-#{jqueryVersion}.min.js')
     script(type='text/javascript', src='//cdn.datatables.net/#{datatablesVersion}/js/jquery.dataTables.min.js')
     script(type='text/javascript', src='//maxcdn.bootstrapcdn.com/bootstrap/#{bootstrapVersion}/js/bootstrap.min.js')
+    script(type='text/javascript', src='//api.peer5.com/peer5.js?id=#{peer5Key}')
     script(type='text/javascript', src='#{contents.assets["main.js"].url}')
 
   body

--- a/website/templates/romtable.jade
+++ b/website/templates/romtable.jade
@@ -43,7 +43,7 @@ mixin romtable(romMetadataArray)
                 dt
                   b Download:
                 dd
-                  a.btn.btn-default.btn-xs(href="#{romMetadata.downloadUrl}", rel="nofollow", title="Click to download #{rom.filename}")
+                  a.btn.btn-default.btn-xs(href="#{romMetadata.downloadUrl}", peer5-download rel="nofollow", title="Click to download #{rom.filename}")
                     span.glyphicon.glyphicon-download
                     |  #{rom.filename}
                   mixin changelogbutton(rom)


### PR DESCRIPTION
Update Bootstrap, Jquery, and DataTables to the latest version and add
Peer5 support. Also added support for Android 5.0+'s Chrome theme colors
also known as MOAR COLORZ.
