### PR TITLE
allow plain text in 'additional information' panel

### DIFF
--- a/website/contents/assets/main.css
+++ b/website/contents/assets/main.css
@@ -27,3 +27,7 @@ dt > small {
 .textcontainer p {
 	padding: 15px;
 }
+
+.textonly {
+	padding: 10px 15px;
+}

--- a/website/templates/layout.jade
+++ b/website/templates/layout.jade
@@ -54,7 +54,10 @@ html(lang='en')
                   -   linkCssClass = 'active';
                   - }
                   li(class=linkCssClass)
-                    a(href=link.src, target=link.target) #{link.text}
+                    if link.src
+                      a(href=link.src, target=link.target) #{link.text}
+                    else
+                      div(style="padding: 10px 15px;") !{link.text}
 
         div.col-xs-12.col-md-9
           block content

--- a/website/templates/layout.jade
+++ b/website/templates/layout.jade
@@ -57,7 +57,7 @@ html(lang='en')
                     if link.src
                       a(href=link.src, target=link.target) #{link.text}
                     else
-                      div(style="padding: 10px 15px;") !{link.text}
+                      div(class="textonly") !{link.text}
 
         div.col-xs-12.col-md-9
           block content


### PR DESCRIPTION
Not sure if I am doing this right, this is my first pull request submission on GitHub. I modified layout.jade to allow for plain text in "customLinks"

it would look something like this in config:
`
customLinks: [
		{ src: "https://github.com/xdarklight/cm-update-server", text: "cm-update-server source", target: "_blank" },
		{ text: "This server is running xdarklight's cm-update-server<br /><br />which is a great open source LineageOS Update Server" }
],
`

It would then look like this:
http://i.imgur.com/6QIan2o.png